### PR TITLE
chore(flake/precommit): `0fe4cc46` -> `a994d570`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,45 +37,22 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "precommit",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "precommit",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -121,11 +98,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1780504325,
-        "narHash": "sha256-EU52VleXVEQrX/CxqdoeQdJNSoWd1yr+0uyCtNFddYg=",
+        "lastModified": 1786105217,
+        "narHash": "sha256-ySp0dc1E9ZorICTvG1467QKzZYCp0fcBECEeycz3Dtw=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "0fe4cc46813614423b1cd54c9de1c74a448c7f3d",
+        "rev": "a994d570247f1d80cbbcd8a33c4b4f866e16af87",
         "type": "github"
       },
       "original": {
@@ -145,11 +122,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1780456895,
-        "narHash": "sha256-CvRZn3Ut0scqLJ1xwQFkZwKGVBUUNBPrFVXRTMZpbfU=",
+        "lastModified": 1786076960,
+        "narHash": "sha256-jfR6OhwurCKn1tREyfOcK/Omxf1Q/DzDDFbnEr1mBLs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7cc96a6a3fd6613cafd633250a3934483479b9a1",
+        "rev": "57a23bfaf4f7017267294b161175db1e32eb1c85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                                                    |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`a994d570`](https://github.com/fredsystems/pre-commit-checks/commit/a994d570247f1d80cbbcd8a33c4b4f866e16af87) | `` chore(flake/nixpkgs): 64380905 -> b7c2ada9 ``                           |
| [`6d588ead`](https://github.com/fredsystems/pre-commit-checks/commit/6d588ead20bf977d4cc6fd499b8760e6f3ccd281) | `` chore(flake/rust-overlay): 29224977 -> 57a23bfa ``                      |
| [`01cf5823`](https://github.com/fredsystems/pre-commit-checks/commit/01cf5823724a9482eb716739e106354e62b14e01) | `` chore(flake/nixpkgs): e2587cae -> 64380905 ``                           |
| [`73eaf96e`](https://github.com/fredsystems/pre-commit-checks/commit/73eaf96e4e293056878278c94ee6063362b282d9) | `` chore(flake/rust-overlay): 6ef009bf -> 29224977 ``                      |
| [`e9cf4ecf`](https://github.com/fredsystems/pre-commit-checks/commit/e9cf4ecff1f40ae5af7ef49d0db56699ba1a5b9e) | `` switch to tscgo ``                                                      |
| [`0bd7d9c7`](https://github.com/fredsystems/pre-commit-checks/commit/0bd7d9c7cec4f68d8ef134ec48be0bac98f4c5fd) | `` switch to tscgo ``                                                      |
| [`e211dcc4`](https://github.com/fredsystems/pre-commit-checks/commit/e211dcc41ca3e096a87df068c701423e5c1e5ab3) | `` switch to tscgo ``                                                      |
| [`b89aae04`](https://github.com/fredsystems/pre-commit-checks/commit/b89aae04fa1bab38b15b5a2023571eb751cc9e85) | `` switch to tscgo ``                                                      |
| [`35e756c3`](https://github.com/fredsystems/pre-commit-checks/commit/35e756c3e429fc8243706b640fc5d3b906e65d04) | `` switch to tscgo ``                                                      |
| [`01acaa60`](https://github.com/fredsystems/pre-commit-checks/commit/01acaa60808b41153970f9b0985ffb142b2ebfe5) | `` chore(flake/rust-overlay): 471286a5 -> 6ef009bf ``                      |
| [`ff4b38d2`](https://github.com/fredsystems/pre-commit-checks/commit/ff4b38d25952a7b818f3b2e0edc749bf6c11b371) | `` chore(flake/nixpkgs): 753cc8a3 -> e2587cae ``                           |
| [`db58dc2e`](https://github.com/fredsystems/pre-commit-checks/commit/db58dc2e11c3a90ba0df698aa6da09199b0ce283) | `` chore(flake/rust-overlay): 06817500 -> 471286a5 ``                      |
| [`8afeac59`](https://github.com/fredsystems/pre-commit-checks/commit/8afeac598b421e3b7b2772eaa699cbdfe967b76c) | `` chore(flake/git-hooks): bca82caa -> 43b3c1ab ``                         |
| [`50bd447e`](https://github.com/fredsystems/pre-commit-checks/commit/50bd447e1d3206ea63716ef6c77ac0deba9f0276) | `` chore(flake/nixpkgs): e7a3ca80 -> 753cc8a3 ``                           |
| [`1f9ef53d`](https://github.com/fredsystems/pre-commit-checks/commit/1f9ef53dcdced2019d6b8ccca22a3f9bb455b819) | `` chore(flake/rust-overlay): a286e5b9 -> 06817500 ``                      |
| [`7ffbe4d2`](https://github.com/fredsystems/pre-commit-checks/commit/7ffbe4d244ef810e871ff616988753131c9595e8) | `` updates ``                                                              |
| [`538e1735`](https://github.com/fredsystems/pre-commit-checks/commit/538e1735c9dc44bb8fc3bc2918a3a5618896a60d) | `` updates ``                                                              |
| [`53d43fa0`](https://github.com/fredsystems/pre-commit-checks/commit/53d43fa05b4de2c1041d41a21d58efae2b674c59) | `` chore(flake/nixpkgs): 0bb7ec54 -> e7a3ca80 ``                           |
| [`fc8d9b93`](https://github.com/fredsystems/pre-commit-checks/commit/fc8d9b9382519b7f1c256da05eebe82aa7aedfaf) | `` chore(flake/rust-overlay): 072adf9b -> a286e5b9 ``                      |
| [`3076ff29`](https://github.com/fredsystems/pre-commit-checks/commit/3076ff29e23e52d8c3cd4c18d8ec086ed6ba8380) | `` chore(flake/nixpkgs): b5aa0fbd -> 0bb7ec54 ``                           |
| [`bc538894`](https://github.com/fredsystems/pre-commit-checks/commit/bc53889457a8989d181d68d3d0d40fbe5f0d0a50) | `` fix(checks): stop failing CI over markdown table widths ``              |
| [`b1c8ac3f`](https://github.com/fredsystems/pre-commit-checks/commit/b1c8ac3f736a4b1a05650867d1492beb2b875b6b) | `` fix(nix): skip flaky nixpkgs pre-commit test_output_isatty on darwin `` |
| [`edc9ac49`](https://github.com/fredsystems/pre-commit-checks/commit/edc9ac49ba8bcf968fcdad3d0605cf8aaddfab90) | `` chore(flake/rust-overlay): e7a078c7 -> 072adf9b ``                      |
| [`63f45c8b`](https://github.com/fredsystems/pre-commit-checks/commit/63f45c8b2c78f4a9b01e274ac68004ff959b930d) | `` chore(flake/rust-overlay): 13139aef -> e7a078c7 ``                      |
| [`5e1f5b7a`](https://github.com/fredsystems/pre-commit-checks/commit/5e1f5b7a2446318f1e3f94396df91a7d096e5cc4) | `` chore(flake/git-hooks): 9f7e9911 -> bca82caa ``                         |
| [`436b4b1f`](https://github.com/fredsystems/pre-commit-checks/commit/436b4b1f99b0ff4fbd2e03af2a90227638b16fb2) | `` chore(deps): lock file maintenance (#35) ``                             |
| [`e91f225e`](https://github.com/fredsystems/pre-commit-checks/commit/e91f225eb26e151c86c865e49147a60fc36d0cca) | `` chore(deps): update actions/checkout action to v7 (#34) ``              |
| [`6241f83d`](https://github.com/fredsystems/pre-commit-checks/commit/6241f83dfeaae7a9c638d6981dcb1fd00a65f020) | `` chore(flake/nixpkgs): 331800de -> b5aa0fbd ``                           |
| [`48bdfcfd`](https://github.com/fredsystems/pre-commit-checks/commit/48bdfcfdcb87a4166433db8929d8d55ef1a1466d) | `` chore(flake/rust-overlay): 7cc96a6a -> 067959ef ``                      |
| [`629f6e81`](https://github.com/fredsystems/pre-commit-checks/commit/629f6e818db41f786956f0cf2524b20006b2eb79) | `` chore(flake/git-hooks): 61ab0e80 -> 3bbec39b ``                         |
| [`191ecb09`](https://github.com/fredsystems/pre-commit-checks/commit/191ecb09a894271680638d03992908e902a5862c) | `` updates ``                                                              |